### PR TITLE
refactor: api_calls 함수에서 중복되는 요소들을 colect_data.py로 이동

### DIFF
--- a/collect_data/api_calls/api_orgs.py
+++ b/collect_data/api_calls/api_orgs.py
@@ -1,17 +1,8 @@
 from yarl import URL
 import requests
-import datetime
-import os
 
 
-HEADERS = {
-    'Accept': 'application/vnd.github+json',
-    'Authorization': f'Bearer {os.environ.get("GITHUB_TOKEN")}',
-    'X-GitHub-Api-Version': '2022-11-28'
-}
-
-
-def get_json(url):
+def get_json(url, HEADERS):
     """
     url로 api 요청을 보내고, 응답값을 json 형태로 반환하는 함수입니다.
 
@@ -25,18 +16,7 @@ def get_json(url):
     return req.json()
 
 
-def get_current_time():
-    """
-    현재 시간과 날짜를 문자열 형태로 반환하는 함수입니다.
-
-    Returns:
-        str -> 2023-05-30 18:42:24
-    """
-    current_datetime = datetime.datetime.now()
-    return current_datetime.strftime("%Y-%m-%d %H:%M:%S")
-
-
-def clean_orgs_data(repo_content):
+def clean_orgs_data(repo_content, CURRENT_TIME):
     """
     organization api 요청 응답 값을 DB에 적재하기 알맞은 형태로 정제하는 함수입니다.
 
@@ -65,11 +45,11 @@ def clean_orgs_data(repo_content):
         'type': repo_content['type'],
         'created_at': repo_content['created_at'],
         'updated_at': repo_content['updated_at'],
-        'called_at': get_current_time()
+        'called_at': CURRENT_TIME
     }
 
 
-def collect_api_orgs(ORGS):
+def collect_api_orgs(HEADERS, ORGS, CURRENT_TIME):
     """
     위 모든 함수들을 종합하여 순차적으로 실행하는 함수로, organization 정보의 집합을 반환합니다.
 
@@ -82,8 +62,8 @@ def collect_api_orgs(ORGS):
     data = []
     for org_name in ORGS:
         url = URL('https://api.github.com').with_path(f'orgs/{org_name}')
-        json_data = get_json(url)
-        values = clean_orgs_data(json_data)
+        json_data = get_json(url, HEADERS)
+        values = clean_orgs_data(json_data, CURRENT_TIME)
         if values['name'] is None:  # name이 없을 경우 명시적으로 회사명 입력하기
             values['name'] = org_name
         data.append(values)

--- a/collect_data/collect_data.py
+++ b/collect_data/collect_data.py
@@ -1,15 +1,35 @@
+import datetime
+import os
 from api_calls.api_orgs import collect_api_orgs
 from dbkit.db_connector import psqlConnector
 from dbkit.queries import *
+
+
+HEADERS = {
+    'Accept': 'application/vnd.github+json',
+    'Authorization': f'Bearer {os.environ.get("GITHUB_TOKEN")}',
+    'X-GitHub-Api-Version': '2022-11-28'
+}
 
 
 ORGS = ['moloco', 'woowabros', 'daangn', 'toss',
         'ncsoft', 'line', 'kakao', 'naver', 'nhn']
 
 
+def get_current_time():
+    """
+    현재 시간과 날짜를 문자열 형태로 반환하는 함수입니다.
+
+    Returns:
+        str -> 2023-05-30 18:42:24
+    """
+    current_datetime = datetime.datetime.now()
+    return current_datetime.strftime("%Y-%m-%d %H:%M:%S")
+
+
 def run():
     db = psqlConnector()
-    orgs_data = collect_api_orgs(ORGS)
+    orgs_data = collect_api_orgs(HEADERS, ORGS, get_current_time())
     for values in orgs_data:
         db.insert_data(API_ORGS_TABLE_INSERT_SQL, values)
     db.disconnect()


### PR DESCRIPTION
api_calls/api_repos.py 에서 HEADERS와 get_current_time은 다른 api_calls에도 중복해서 사용할 것 같아서, 모든 api_call 들을 호출하는 collect_data.py 로 옮겼습니다. 
이후 api_call 함수를 호출할 때는 HEADERS, CURRENT_TIME으로 함수에 인자로 넘겨주게 했습니다.