### PR TITLE
dev: environment variables setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=''
+DB_NAME='ostracker'
+DB_USER_NAME=''
+DB_USER_PASSWORD=''
+DB_PORT='5432'
+API_TOKEN=''

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DB_HOST=''
-DB_NAME='ostracker'
+DB_NAME=''
 DB_USER_NAME=''
 DB_USER_PASSWORD=''
-DB_PORT='5432'
+DB_PORT=''
 API_TOKEN=''

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,pycharm,macos,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode,pycharm,macos,windows
 
+set_env_vars.sh
+
 ### macOS ###
 # General
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,pycharm,macos,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode,pycharm,macos,windows
 
-set_env_vars.sh
-
 ### macOS ###
 # General
 .DS_Store

--- a/collect_data/collect_data.py
+++ b/collect_data/collect_data.py
@@ -3,6 +3,10 @@ import os
 from api_calls.api_orgs import collect_api_orgs
 from dbkit.db_connector import psqlConnector
 from dbkit.queries import *
+from dotenv import load_dotenv
+
+load_dotenv()
+
 
 
 HEADERS = {
@@ -35,6 +39,8 @@ def run():
     for values in orgs_data:
         db.insert_data(API_ORGS_TABLE_INSERT_SQL, values)
     db.disconnect()
+
+
 
 
 if __name__ == "__main__":

--- a/collect_data/collect_data.py
+++ b/collect_data/collect_data.py
@@ -7,7 +7,7 @@ from dbkit.queries import *
 
 HEADERS = {
     'Accept': 'application/vnd.github+json',
-    'Authorization': f'Bearer {os.environ.get("GITHUB_TOKEN")}',
+    'Authorization': f'Bearer {os.environ.get("API_TOKEN")}',
     'X-GitHub-Api-Version': '2022-11-28'
 }
 

--- a/collect_data/dbkit/db_connector.py
+++ b/collect_data/dbkit/db_connector.py
@@ -1,7 +1,9 @@
 from psycopg2.extras import execute_batch
 import psycopg2
 import os
+from dotenv import load_dotenv
 
+load_dotenv()
 
 class psqlConnector:
     def __init__(self):

--- a/collect_data/dbkit/db_connector.py
+++ b/collect_data/dbkit/db_connector.py
@@ -6,11 +6,11 @@ import os
 class psqlConnector:
     def __init__(self):
         self.conn = psycopg2.connect(
-            host=os.environ.get('HOST'),
-            dbname=os.environ.get('DATABASE'),
-            user=os.environ.get('USER'),
-            password=os.environ.get('PASSWORD'),
-            port=os.environ.get('DBPORT')
+            host=os.environ.get('DB_HOST'),
+            dbname=os.environ.get('DB_NAME'),
+            user=os.environ.get('DB_USER_NAME'),
+            password=os.environ.get('DB_USER_PASSWORD'),
+            port=os.environ.get('DB_PORT')
         )
 
     def _database(self):

--- a/collect_data/dbkit/db_connector.py
+++ b/collect_data/dbkit/db_connector.py
@@ -1,9 +1,6 @@
 from psycopg2.extras import execute_batch
 import psycopg2
 import os
-from dotenv import load_dotenv
-
-load_dotenv()
 
 class psqlConnector:
     def __init__(self):

--- a/collect_data/playground/api_repos_commits_uploader.py
+++ b/collect_data/playground/api_repos_commits_uploader.py
@@ -49,9 +49,9 @@ def save_info_to_commits_table(
     
     host = os.environ.get('DB_HOST')
     port = os.environ.get('DB_PORT')
-    database = os.environ.get('DB_DATABASE')
-    user = os.environ.get('DB_USER')
-    password = os.environ.get('DB_PASSWORD')
+    database = os.environ.get('DB_NAME')
+    user = os.environ.get('DB_USER_NAME')
+    password = os.environ.get('DB_USER_PASSWORD')
 
     conn = psycopg2.connect(
         host=host,
@@ -132,7 +132,7 @@ def collect_api_repos_commits(repo_full_name):
     """
 
     load_dotenv() # .env file load. in playground folder
-    access_token = os.environ.get('ACCESS_TOKEN')
+    access_token = os.environ.get('API_TOKEN')
 
     url = f'https://api.github.com/repos/{repo_full_name}/commits?per_page=100'
 
@@ -164,9 +164,9 @@ def collect_api_repos_commits(repo_full_name):
 
     host = os.environ.get('DB_HOST')
     port = os.environ.get('DB_PORT')
-    database = os.environ.get('DB_DATABASE')
-    user = os.environ.get('DB_USER')
-    password = os.environ.get('DB_PASSWORD')
+    database = os.environ.get('DB_NAME')
+    user = os.environ.get('DB_USER_NAME')
+    password = os.environ.get('DB_USER_PASSWORD')
 
     conn = psycopg2.connect(
         host=host,


### PR DESCRIPTION
repo에 시크릿을 직접 저장하지 않고 github action이 쓸 수 있도록 github에서 따로 환경 변수 설정을 했습니다.
지난 pr에서는 이에 맞춰서 개발과 프로덕션 코드를 동일하게 가져가기 위해 코드에서 환경 변수를 설정하는 코드를 제거하고 바로 os.environ.get(~) 방식으로 환경 변수를 가져와서 사용하도록 코드를 수정했습니다.
로컬에서 개발할 때는 파이썬을 실행하기 전에 set_env_vars.sh 을 실행해서 환경변수를 세팅해야 합니다. (이 스크립트는 슬랙을 통해 공유하겠습니다.)

이번 pr에서는 다음과 같은 사항이 변경되었습니다.
1. .gitignore에 set_env_vars.sh 추가
2. db_connector.py, collect_data.py 의 환경변수 이름 재설정 <- github action을 위해 설정한 환경변수명과 set_env_vars.sh을 통해 설정하는 환경변수명, 코드에서의 환경변수명을 통일시켰습니다.

