### PR TITLE
fix: add state, filter params to api-repos-issues

### DIFF
--- a/collect_data/api_calls/api_repos_issues.py
+++ b/collect_data/api_calls/api_repos_issues.py
@@ -41,7 +41,11 @@ def collect_api_repos_issues(HEADERS, repos, CURRENT_TIME):
     for repo in repos:
         url = f'https://api.github.com/repos/{repo}/issues'
         issues = []
-        params = {'page': 1}
+        default_params = {
+            'state': 'all',
+            'filter': 'all',
+        }
+        params = dict(default_params, **{'page': 1})
 
         # pagenation
         while True:
@@ -51,7 +55,7 @@ def collect_api_repos_issues(HEADERS, repos, CURRENT_TIME):
                 issues.extend(json_data)
                 if 'next' in response.links:
                     url = response.links['next']['url']
-                    params = {}
+                    params = default_params
                 else:
                     break
             else:


### PR DESCRIPTION
기존 collect_api_repos_issues 함수에서 closed된 issue는 가져오지 않는 문제가 있었습니다. 해당 문제를 해결하는 PR입니다.

https://github.com/opensource-tracker/opensource-tracker/pull/16#discussion_r1214029344