### PR TITLE
fix: api_repos_commits PK insert except rollback

### DIFF
--- a/collect_data/dbkit/db_connector.py
+++ b/collect_data/dbkit/db_connector.py
@@ -30,8 +30,8 @@ class psqlConnector:
 
             print(">>> Successfully inserted data into table")
 
-        except errors.UniqueViolation:
-            pass # api_repos_commits_sha 중복 값 처리
+        except errors.UniqueViolation: # api_repos_commits_sha 중복 값 처리
+            self.conn.rollback()
         except psycopg2.Error as e:
             self.conn.rollback()
             print(f">>> failed insert data into table: {e}")
@@ -47,9 +47,8 @@ class psqlConnector:
             _cur.close()
             print(">>> Successfully inserted data into table")
 
-        except errors.UniqueViolation:
-            pass # api_repos_commits_sha 중복 값 처리
-
+        except errors.UniqueViolation: # api_repos_commits_sha 중복 값 처리
+            self.conn.rollback()
         except psycopg2.Error as e:
             self.conn.rollback()
             print(f">>> failed insert data into table: {e}")


### PR DESCRIPTION
- commits 에서 이미 테이블에 저장된 커밋일 경우 (이미 존재하는 sha PK insert), except 에러 메시지가 출력되는 문제를 해결했습니다.