### PR TITLE
fix: ELT license 관련 쿼리 필드 이름 수정

### DIFF
--- a/collect_data/dbkit/queries.py
+++ b/collect_data/dbkit/queries.py
@@ -58,7 +58,7 @@ VALUES %s;
 ELT_LICENSES_PER_REPOS_TABLE_CREATE_SQL = """
 DROP TABLE IF EXISTS analytics.licenses_per_repos;
 CREATE TABLE analytics.licenses_per_repos (
-    repo VARCHAR(255),
+    repo_full_name VARCHAR(255),
     organization VARCHAR(255),
     name VARCHAR(255),
     spdx_id VARCHAR(40)
@@ -66,9 +66,9 @@ CREATE TABLE analytics.licenses_per_repos (
 """
 
 ELT_LICENSES_PER_REPOS_TABLE_INSERT_SQL = """
-INSERT INTO analytics.licenses_per_repos (repo, organization, name, spdx_id)
+INSERT INTO analytics.licenses_per_repos (repo_full_name, organization, name, spdx_id)
 SELECT
-  DISTINCT repos.full_name as repo,
+  DISTINCT repos.full_name as repo_full_name,
   orgs.name as organization,
   ls.name,
   ls.spdx_id


### PR DESCRIPTION

## 작업

- `repo`에서 `repo_full_name`으로 수정하였습니다.

## 맥락

- [slack](https://greppkdt-hq.slack.com/archives/C05AB0CPPL0/p1688107837805059?thread_ts=1688100725.146219&cid=C05AB0CPPL0)
