### PR TITLE
테이블 통합으로 인한 query문 및 task 삭제

### DIFF
--- a/collect_data/dbkit/queries.py
+++ b/collect_data/dbkit/queries.py
@@ -151,32 +151,6 @@ JOIN raw_data.api_orgs org ON repos.owner_id = org.orgs_id
 WHERE lang.called_at = (SELECT called_at FROM raw_data.api_repos_languages ORDER BY 1 DESC LIMIT 1)
 """
 
-ELT_REPO_INFO_PER_ORGS_TABLE_CREATE_SQL = """
-DROP TABLE IF EXISTS analytics.repo_info_per_orgs;
-CREATE TABLE analytics.repo_info_per_orgs (
-    organization VARCHAR(255),
-    repo VARCHAR(255),
-    updated_at TIMESTAMPTZ 
-);
-""" 
-
-ELT_REPO_INFO_PER_ORGS_TABLE_INSERT_SQL = """
-INSERT INTO analytics.repo_info_per_orgs (organization, repo, updated_at)
-SELECT
-    orgs.name AS organization,
-    repo.name AS repo,
-    repo.updated_at AS updated_at
-FROM raw_data.api_repos AS repo
-LEFT JOIN
-      (SELECT 
-            DISTINCT(orgs_id),
-            name
-      FROM raw_data.api_orgs
-      WHERE called_at = (SELECT called_at FROM raw_data.api_orgs ORDER BY called_at DESC LIMIT 1)
-      ) AS orgs ON repo.owner_id = orgs.orgs_id
-WHERE called_at = (SELECT called_at FROM raw_data.api_repos ORDER BY called_at DESC LIMIT 1);
-"""
-
 ELT_ISSUES_PER_ORGS_TABLE_CREATE_SQL = """
 DROP TABLE IF EXISTS analytics.issues_per_orgs;
 CREATE TABLE analytics.issues_per_orgs (

--- a/dags/elt_to_analytics.py
+++ b/dags/elt_to_analytics.py
@@ -79,14 +79,6 @@ def create_contributors_per_repos_and_day_table():
     ])
 
 @task()
-def create_repo_info_per_orgs_table():
-    execute_sqls([
-        queries.ELT_REPO_INFO_PER_ORGS_TABLE_CREATE_SQL,
-        queries.ELT_REPO_INFO_PER_ORGS_TABLE_INSERT_SQL,
-        ])
-        
-
-@task()
 def create_stars_per_orgs_table():
     execute_sqls([
         queries.ELT_STARS_PER_ORGS_TABLE_CREATE_SQL,
@@ -113,7 +105,6 @@ def elt_to_analytics():
         create_recent_repos_table(),
         create_languages_per_repos_table(),
         create_commits_per_repos_and_sha_table(),
-        create_repo_info_per_orgs_table(),
         create_issues_per_orgs_table(),
         create_stars_per_orgs_table(),
     ] >> create_contributors_per_repos_and_day_table() >> end


### PR DESCRIPTION
repo_info_per_orgs와 recent_repo 테이블이 동일한 데이터를 가지고 있어서 repo_info_per_orgs를 삭제했습니다.
- `queries.py` 내 관련 `CREATE`, `INSERT`문 제거
- `elt_to_analytics.py` 내 task 및 실행 순서 제거