### PR TITLE
Fix: analytics 중복 테이블 삭제

### DIFF
--- a/collect_data/dbkit/queries.py
+++ b/collect_data/dbkit/queries.py
@@ -193,36 +193,6 @@ LEFT JOIN
 WHERE issue.called_at = (SELECT called_at FROM raw_data.api_repos_issues ORDER BY called_at DESC LIMIT 1); 
 """
 
-ELT_STARS_PER_ORGS_TABLE_CREATE_SQL = """
-DROP TABLE IF EXISTS analytics.stars_per_orgs;
-CREATE TABLE analytics.stars_per_orgs (
-    organization VARCHAR(255),
-    repo VARCHAR(255),
-    star_count INT, 
-    language VARCHAR(50),
-    description TEXT
-);
-"""
-
-ELT_STARS_PER_ORGS_TABLE_INSERT_SQL = """
-INSERT INTO analytics.stars_per_orgs (organization, repo, star_count, language, description)
-SELECT
-    orgs.name AS organization,
-    repo.name AS repo,
-    stargazers_count AS star_count,
-    repo.language,
-    repo.description AS description
-FROM raw_data.api_repos AS repo
-LEFT JOIN
-      (SELECT 
-          DISTINCT(orgs_id),
-            name
-      FROM raw_data.api_orgs
-      WHERE called_at = (SELECT called_at FROM raw_data.api_orgs ORDER BY called_at DESC LIMIT 1)
-      ) AS orgs ON repo.owner_id = orgs.orgs_id
-WHERE called_at = (SELECT called_at FROM raw_data.api_repos ORDER BY called_at DESC LIMIT 1);
-"""
-
 ELT_COMMITS_PER_REPOS_TABLE_CREATE_SQL = """
 DROP TABLE IF EXISTS analytics.commits_per_repos;
 CREATE TABLE analytics.commits_per_repos (

--- a/dags/elt_to_analytics.py
+++ b/dags/elt_to_analytics.py
@@ -78,13 +78,6 @@ def create_contributors_per_repos_table():
     ])
 
 @task()
-def create_stars_per_orgs_table():
-    execute_sqls([
-        queries.ELT_STARS_PER_ORGS_TABLE_CREATE_SQL,
-        queries.ELT_STARS_PER_ORGS_TABLE_INSERT_SQL,
-        ])
-
-@task()
 def create_issues_per_orgs_table():
     execute_sqls([
         queries.ELT_ISSUES_PER_ORGS_TABLE_CREATE_SQL,
@@ -112,7 +105,6 @@ def elt_to_analytics():
         create_languages_per_repos_table(),
         create_commits_per_repos_table(),
         create_issues_per_orgs_table(),
-        create_stars_per_orgs_table(),
         create_stargazers_count_per_repos_table(),
     ] >> create_contributors_per_repos_table() >> end
 


### PR DESCRIPTION
Analytics에서 불필요한 중복 테이블(STARS_PER_ORGS_TABLE) 관련 구문을 삭제했습니다.

- `dags/elt_to_analytics.py` 내  `create_stars_per_orgs_table()` task 삭제
-  `collect_data/dbkit/queries.py` 내 `STARS_PER_ORGS_TABLE` `CREATE, INSERT` 문 삭제